### PR TITLE
Add support UI for disabled repositories

### DIFF
--- a/src/app/repo/_layout/Meta.tsx
+++ b/src/app/repo/_layout/Meta.tsx
@@ -9,8 +9,8 @@ import { getAvatarUrl, truncate } from "@/utils";
 
 import { SettingsButton } from "./SettingsButton";
 import { VerificationIcon } from "@/components/VerificationIcon/VerificationIcon";
-import { ArrowTopRightOnSquareIcon, LinkIcon } from "@heroicons/react/24/outline";
 import { GithubLogoIcon } from "@/components/Icons/GithubLogo";
+import appConfig from "@/appConfig";
 
 interface IMetaProps {
   owner: string;
@@ -29,6 +29,8 @@ export const Meta: FC<IMetaProps> = async ({ owner, repo }) => {
 
   if (!metaData) return notFound();
 
+  const disabled = appConfig.DISABLED_REPOS.includes(`${owner}/${repo}`);
+
   return <>
     <div className="flex flex-col md:flex-row justify-between  md:items-center">
 
@@ -43,10 +45,10 @@ export const Meta: FC<IMetaProps> = async ({ owner, repo }) => {
 
         <SettingsButton owner={owner} repo={repo} />
 
-        <DonateModal
+        {!disabled ? <DonateModal
           owner={owner}
           repo={repo}
-        />
+        /> : <div className="p-4 text-gray-900 border rounded-xl border-gray-900">This repository doesn't receive donations</div>}
       </div>
     </div>
 

--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -18,4 +18,7 @@ export default {
   INTRODUCTORY_ARTICLE_URL: "https://blog.obyte.org/kivach-cascading-donations-for-github-repositories-2b175bdbff77",
   STATUS_BOT_PAIRING_URL: process.env.NEXT_PUBLIC_STATUS_BOT_PAIRING_URL,
   GA_TAG_ID: process.env.NEXT_PUBLIC_GA_TAG_ID,
+  DISABLED_REPOS: [
+    "qubesos/qubes-secpack"
+  ]
 }


### PR DESCRIPTION
Introduce a user interface that informs users when a repository is disabled from receiving donations, enhancing the donation modal experience.

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/a5e73c98-1626-4bdc-bf06-74f1ffbe6561">
